### PR TITLE
Bootstrap Datepicker no longer supports "pickTime" or "pickSecond" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,10 @@ from django import forms
       todo = forms.CharField(
           widget=forms.TextInput(attrs={"class": "form-control"}))
       date = forms.DateField(
-          widget=DateTimePicker(options={"format": "YYYY-MM-DD",
-                                         "pickTime": False}))
+          widget=DateTimePicker(options={"format": "YYYY-MM-DD"}))
       reminder = forms.DateTimeField(
           required=False,
-          widget=DateTimePicker(options={"format": "YYYY-MM-DD HH:mm",
-                                         "pickSeconds": False}))
+          widget=DateTimePicker(options={"format": "YYYY-MM-DD HH:mm"}))
 ```
 
 The `options` will be passed to the JavaScript datetimepicker instance. 


### PR DESCRIPTION
Bootstrap 3 Datepicker no longer supports `pickTime` and `pickSeconds` options.  According to [the docs](https://eonasdan.github.io/bootstrap-datetimepicker/Options/):   

> Format also dictates what components are shown, e.g. MM/dd/YYYY will not display the time picker.
