### PR TITLE
Allowing jQuery to be loaded later in the page

### DIFF
--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -49,9 +49,16 @@ class DateTimePicker(DateTimeInput):
 
     js_template = """
     <script>
-      $(function(){
-        $("#%(picker_id)s:has(input:not([readonly],[disabled]))").datetimepicker(%(options)s);
-      });
+        (function(window) {
+            var callback = function() {
+                $(function(){$("#%(picker_id)s:has(input:not([readonly],[disabled]))").datetimepicker(%(options)s);});
+            };
+            if(window.addEventListener)
+                window.addEventListener("load", callback, false);
+            else if (window.attachEvent)
+                window.attachEvent("onload", callback);
+            else window.onload = callback;
+        })(window);
     </script>"""
 
     def __init__(self, attrs=None, format=None, options=None, div_attrs=None, icon_attrs=None):


### PR DESCRIPTION
This commit allows for jQuery to be defined in the footer of the page, and defers loading the date picker until the entire window has loaded. Without this, I was getting an error about `$` not being defined.

I took the JS from the original `django-bootstrap3-datetimepicker` lib: https://github.com/nkunihiko/django-bootstrap3-datetimepicker/blob/master/bootstrap3_datetime/widgets.py#L90.