### PR TITLE
Update of Readme to reflect compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ draw out your HTML manually.
 ## Requirements
 
 * Python >= 2.7
-* Django >= 1.8
+* Django >= 1.11
 * Bootstrap == 3.X
 * Moment >= 2.10.6
 * bootstrap-datetimepicker >= 4.15.35

--- a/README.md
+++ b/README.md
@@ -72,3 +72,15 @@ draw out your HTML manually.
 * Bootstrap == 3.X
 * Moment >= 2.10.6
 * bootstrap-datetimepicker >= 4.15.35
+
+### Backwards Compatibility
+
+If you want to use the picker in a Django 1.9 or 1.10 project, you can adapt by overwriting `build_attrs` with
+
+```python
+def build_attrs(self, base_attrs=None, extra_attrs=None, **kwargs):
+    if extra_attrs:
+        base_attrs.update(extra_attrs)
+    base_attrs.update(kwargs)
+    return super().build_attrs(**base_attrs)
+```


### PR DESCRIPTION
Merging PRs broke the Django 1.9 and 1.10 compatibility. This makes the fact clear in the Readme and offers a backwards wrapper.