### PR TITLE
Avoid possible _format_value() recursion

### DIFF
--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -83,10 +83,12 @@ class DateTimePicker(DateTimeInput):
 
     def _format_value(self, value):
         """This function name was changed in Django 1.10 and removed in 2.0."""
+        # Use renamed format_name() for Django versions >= 1.10.
         if hasattr(self, 'format_value'):
-            return self.format_value(value)
+            return super(DateTimePicker, self).format_value(value)
+        # Use old _format_name() for Django versions < 1.10.
         else:
-            return self._format_value(value)
+            return super(DateTimePicker, self)._format_value(value)
 
     def render(self, name, value, attrs=None):
         if value is None:


### PR DESCRIPTION
Currently `RecursionError` is raised in python3 with Django 1.11.  
This is probably caused by the way deprecation works in Django. We need to call parent's `format_value` to avoid this. 