### PR TITLE
added renderer argument for django 2.1 compat

### DIFF
--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -90,7 +90,7 @@ class DateTimePicker(DateTimeInput):
         else:
             return super(DateTimePicker, self)._format_value(value)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = ''
 


### PR DESCRIPTION
This fixes Issue #19 by simply accepting the renderer keyword, but not using it for anything