### PR TITLE
feat(DateTimePicker): replace deprecated force_text (& add test)

### DIFF
--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -5,7 +5,7 @@ from django.forms.utils import flatatt
 from django.forms.widgets import DateTimeInput
 from django.utils.safestring import mark_safe
 from django.utils.html import conditional_escape
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 
 class DateTimePicker(DateTimeInput):
@@ -101,7 +101,7 @@ class DateTimePicker(DateTimeInput):
 
         if value != '':
             # Only add the 'value' attribute if a value is non-empty.
-            input_attrs['value'] = force_text(self._format_value(value))
+            input_attrs['value'] = force_str(self._format_value(value))
         input_attrs = {key: conditional_escape(val) for key, val in input_attrs.items()}
         if not self.picker_id:
              self.picker_id = (input_attrs.get('id', '') +
@@ -117,4 +117,4 @@ class DateTimePicker(DateTimeInput):
             js = self.js_template % dict(picker_id=picker_id, options=json.dumps(self.options or {}))
         else:
             js = ''
-        return mark_safe(force_text(html + js))
+        return mark_safe(force_str(html + js))

--- a/tests/legacy.py
+++ b/tests/legacy.py
@@ -1,0 +1,16 @@
+import django
+
+from bootstrap3_datetime.widgets import DateTimePicker
+
+
+class DateTimePickerDjango110(DateTimePicker):
+    def build_attrs(self, base_attrs=None, extra_attrs=None, **kwargs):
+        if extra_attrs:
+            base_attrs.update(extra_attrs)
+        base_attrs.update(kwargs)
+        return super(DateTimePickerDjango110, self).build_attrs(**base_attrs)
+
+
+def is_legacy():
+    x,y,z = [int(v) for v in django.__version__.split(".")]
+    return x == 1 and y < 11

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,0 +1,12 @@
+import json
+
+from legacy import DateTimePickerDjango110, is_legacy
+
+from bootstrap3_datetime.widgets import DateTimePicker
+
+
+def test_rendering():
+    options = {"pickTime": True, "format": "YYYY-MM-DD HH:mm"}
+    widget = (DateTimePickerDjango110 if is_legacy() else DateTimePicker)(options=options)
+    expected_output = '\n    <div class="input-group date" id="_pickers">\n      <input class="form-control" name="a" type="text" value="b"/>\n      <span class="input-group-addon">\n        <span class="glyphicon glyphicon-calendar"></span>\n      </span>\n    </div>\n    <script>\n        (function(window) {\n            var callback = function() {\n                $(function(){$("#_pickers:has(input:not([readonly],[disabled]))").datetimepicker(%s);});\n            };\n            if(window.addEventListener)\n                window.addEventListener("load", callback, false);\n            else if (window.attachEvent)\n                window.attachEvent("onload", callback);\n            else window.onload = callback;\n        })(window);\n    </script>'
+    assert widget.render("a", "b", {}) == expected_output % json.dumps(options)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist =
+    {py27}-{django10,django111}
+    {py39}-{django10,django111,django20,django30,django40}
+
+[testenv]
+commands =
+    pytest
+deps =
+    pytest
+    django10: django==1.10.*
+    django111: django==1.11.*
+    django20: django==2.0.*
+    django30: django==3.0.*
+    django40: django==4.0.*
+setenv   =
+    PYTHONPATH = {toxinidir}


### PR DESCRIPTION
Hey :wave: 

A minor update that makes the lib compatible with Django 4.
I added tests using [tox](https://tox.wiki/en/latest/) to ensure compatibility with other Django versions. 

```
$> tox
[...]
py27-django10: commands succeeded
py27-django111: commands succeeded
py39-django10: commands succeeded
py39-django111: commands succeeded
py39-django20: commands succeeded
py39-django30: commands succeeded
py39-django40: commands succeeded
congratulations :)
```